### PR TITLE
Fix #221.

### DIFF
--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -7,7 +7,6 @@
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet" type="text/css">
   <meta content="Bikeshed version 0dd2bba6dfda6c3168490a3a3044dd1d0b1ef8e0" name="generator">
   <link href="https://w3c.github.io/webappsec-trusted-types/dist/spec/" rel="canonical">
-  <meta content="8fcc1c14866afbfba65ac47f78fecebf6f8cad8c" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -254,7 +253,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Trusted Types</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-13">13 November 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-11-15">15 November 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -358,13 +357,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
         <li><a href="#should-block-sink-type-mismatch"><span class="secno">4.5.2</span> <span class="content"><span>Should sink type mismatch violation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#should-block-create-policy"><span class="secno">4.5.3</span> <span class="content"><span>Should Trusted Type policy creation be blocked by Content Security Policy?</span></span></a>
         <li><a href="#csp-violation-object-hdr"><span class="secno">4.5.4</span> <span class="content">Violation object changes</span></a>
-        <li>
-         <a href="#trusted-script-csp-keyword"><span class="secno">4.5.5</span> <span class="content">'trusted-script' keyword</span></a>
-         <ol class="toc">
-          <li><a href="#csp-trusted-script-eval"><span class="secno">4.5.5.1</span> <span class="content">'trusted-script' support for eval</span></a>
-          <li><a href="#csp-trusted-script-javascript-url"><span class="secno">4.5.5.2</span> <span class="content">'trusted-script' support for javascript: URLs</span></a>
-         </ol>
-        <li><a href="#is-source-exempt-algorithm"><span class="secno">4.5.6</span> <span class="content"><span>IsSourceExempt</span> Algorithm</span></a>
+        <li><a href="#csp-eval"><span class="secno">4.5.5</span> <span class="content">Support for eval(TrustedScript)</span></a>
        </ol>
      </ol>
     <li>
@@ -1589,7 +1582,8 @@ which value is <var>policyName</var>, set <var>createViolation</var> to true.</p
    </ol>
    <h4 class="heading settled" data-level="4.5.4" id="csp-violation-object-hdr"><span class="secno">4.5.4. </span><span class="content">Violation object changes</span><a class="self-link" href="#csp-violation-object-hdr"></a></h4>
    <p><a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#violation" id="ref-for-violation">Violation</a> object <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#violation-resource" id="ref-for-violation-resource②">resource</a> also allows <code>"trusted-types-policy"</code> and <code>"trusted-types-sink"</code> as values.</p>
-   <h4 class="heading settled" data-level="4.5.5" id="trusted-script-csp-keyword"><span class="secno">4.5.5. </span><span class="content">'trusted-script' keyword</span><a class="self-link" href="#trusted-script-csp-keyword"></a></h4>
+   <h4 class="heading settled" data-level="4.5.5" id="csp-eval"><span class="secno">4.5.5. </span><span class="content">Support for eval(TrustedScript)</span><a class="self-link" href="#csp-eval"></a></h4>
+   <p>This document modifies the <a href="https://www.w3.org/TR/CSP3/#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation</a> which is reproduced in its entirety below with additions and deletions.</p>
    <p class="note" role="note"><span>Note:</span> See <a href="https://github.com/tc39/ecma262/issues/938">TC39/ecma262 issue #938</a> (adding the value to be compiled to algorithm parameters).</p>
    <div class="note" role="note">
     Note: EcmaScript code may call <code>Function()</code> and <code>eval</code> cross realm. 
@@ -1606,13 +1600,6 @@ self<c- p>.</c->top<c- p>.</c->body<c- p>.</c->innerHTML <c- o>=</c-> <c- t>'Hel
     <p>This is subtly different from the CSP directive enforcement portion which rejects if either
 the <var>calleeRealm</var> or <var>callerRealm</var>’s Content-Security-Policy rejects string compilation.</p>
    </div>
-   <p>This document modifies the grammar for <a href="https://www.w3.org/TR/CSP3/#keyword-source">Content Security Policy Level 3 §keyword-source</a>:</p>
-<pre><dfn data-dfn-type="grammar" data-export id="grammardef-keyword-source">keyword-source<a class="self-link" href="#grammardef-keyword-source"></a></dfn> = "'self'" / "'unsafe-inline'" / "'unsafe-eval'"
-                     / "'strict-dynamic'" / "'unsafe-hashes'" / "'report-sample'"
-                     / "'unsafe-allow-redirects'" <ins>/ "<dfn class="dfn-paneled" data-dfn-type="grammar" data-export id="grammardef-trusted-script">'trusted-script'</dfn>"</ins>
-</pre>
-   <h5 class="heading settled" data-level="4.5.5.1" id="csp-trusted-script-eval"><span class="secno">4.5.5.1. </span><span class="content">'trusted-script' support for eval</span><a class="self-link" href="#csp-trusted-script-eval"></a></h5>
-   <p>This document modifies the <a href="https://www.w3.org/TR/CSP3/#can-compile-strings">EnsureCSPDoesNotBlockStringCompilation</a> which is reproduced in its entirety below with additions and deletions.</p>
    <p>
     Given two <a href="https://tc39.es/ecma262/#realm">realms</a> (<var>callerRealm</var> and <var>calleeRealm</var>), and a 
     <del>string</del>
@@ -1641,14 +1628,6 @@ throws an "<code>EvalError</code>" if not:
     <li data-md>
      <ins>If the algorithm throws an error, throw an <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#exceptiondef-evalerror" id="ref-for-exceptiondef-evalerror">EvalError</a></code>.</ins>
     <li data-md>
-     <ins>
-      Let <var>isExempt</var> be the result of executing the <a data-link-type="abstract-op" href="#abstract-opdef-issourceexempt" id="ref-for-abstract-opdef-issourceexempt">IsSourceExempt</a> algorithm with: 
-      <ul>
-       <li data-md>
-        <p><var>calleeRealm</var>’s <code class="idl"><a data-link-type="idl">CSP list</a></code> as <var>cspList</var>.</p>
-      </ul>
-     </ins>
-    <li data-md>
      <p>Let <var>globals</var> be a list containing <var>calleeRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global⑤">global object</a> and <var>calleeRealm</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#concept-realm-global" id="ref-for-concept-realm-global⑥">global object</a>.</p>
     <li data-md>
      <p>For each <var>global</var> in <var>globals</var>:</p>
@@ -1666,11 +1645,8 @@ set <var>source-list</var> to that <a data-link-type="dfn" href="https://w3c.git
          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives⑥">directive</a> whose <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-name" id="ref-for-directive-name③">name</a> is
 "<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑤">value</a>.</p>
         <li data-md>
-         <ins>If <var>isExempt</var> is true and <var>source-list</var> contains a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#source-expression" id="ref-for-source-expression">source expression</a> which is an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the
-string "<a data-link-type="grammar" href="#grammardef-trusted-script" id="ref-for-grammardef-trusted-script"><code>'trusted-script'</code></a>"), <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#iteration-continue" id="ref-for-iteration-continue">continue</a>.</ins>
-        <li data-md>
-         <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#source-expression" id="ref-for-source-expression①">source expression</a> which is
-an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive①">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>" then:</p>
+         <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#source-expression" id="ref-for-source-expression">source expression</a> which is
+an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>" then:</p>
          <ol>
           <li data-md>
            <p>Let <var>violation</var> be the result of executing <a href="https://www.w3.org/TR/CSP3/#create-violation-for-global">Content Security Policy Level 3 §create-violation-for-global</a> on <var>global</var>, <var>policy</var>, and "<code>script-src</code>".</p>
@@ -1711,25 +1687,6 @@ Is this a feature or a bug?</p>
    <p class="note" role="note"><span>Note:</span> The previous algorithm reports violations via both report-uris where
 callerRealm != calleeRealm.  If <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string⑨">Get Trusted Type compliant string</a> reports an
 error, it only reports it via its <var>calleeRealm</var>’s report-uri.</p>
-   <h5 class="heading settled" data-level="4.5.5.2" id="csp-trusted-script-javascript-url"><span class="secno">4.5.5.2. </span><span class="content">'trusted-script' support for javascript: URLs</span><a class="self-link" href="#csp-trusted-script-javascript-url"></a></h5>
-   <p>This document modifies the <a href="https://www.w3.org/TR/CSP3/#match-element-to-source-list">Does element match source list for type and source?</a> algorithm, for it to recognize the 'trusted-script' keyword for <code>javascript:</code> navigations.</p>
-   <p>Add the following step after step 1:</p>
-   <ol start="2">
-    <li data-md>
-     <p>If <var>type</var> is <code>"navigation"</code>, <var>list</var> <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#list-contain" id="ref-for-list-contain①">contains</a> an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive②">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="#grammardef-trusted-script" id="ref-for-grammardef-trusted-script①"><code>'trusted-script'</code></a>" and <a data-link-type="abstract-op" href="#abstract-opdef-issourceexempt" id="ref-for-abstract-opdef-issourceexempt①">IsSourceExempt</a> algorithm executed on <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/browsers.html#active-document" id="ref-for-active-document">active document</a>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list③">CSP list</a> returns true,
-return <code>"Matches"</code>.</p>
-   </ol>
-   <h4 class="heading settled" data-level="4.5.6" id="is-source-exempt-algorithm"><span class="secno">4.5.6. </span><span class="content"><dfn class="dfn-paneled" data-dfn-type="abstract-op" data-export id="abstract-opdef-issourceexempt">IsSourceExempt</dfn> Algorithm</span><a class="self-link" href="#is-source-exempt-algorithm"></a></h4>
-   <p>The IsSourceExempt algorithm takes a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list④">CSP List</a> (<var>cspList</var>) and executes
-the following steps:</p>
-   <ol>
-    <li data-md>
-     <p>If <var>cspList</var> contains a <a href="https://www.w3.org/TR/CSP3/#content-security-policy-object">policy</a> whose <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#policy-directive-set" id="ref-for-policy-directive-set③">directive set</a> contains a <a href="https://www.w3.org/TR/CSP3/#directives">directive</a> with a name <code>"trusted-types"</code>, return true.</p>
-    <li data-md>
-     <p>Return false.</p>
-   </ol>
-   <p class="note" role="note"><span>Note:</span> This checks whether Trusted Types enforcement would have rejected the
-input, were it problematic in the callout to <a data-link-type="abstract-op" href="#abstract-opdef-get-trusted-type-compliant-string" id="ref-for-abstract-opdef-get-trusted-type-compliant-string①⓪">Get Trusted Type compliant string</a>.</p>
    <h2 class="heading settled" data-level="5" id="security-considerations"><span class="secno">5. </span><span class="content">Security Considerations</span><a class="self-link" href="#security-considerations"></a></h2>
    <p>Trusted Types are not intended to defend against XSS in an actively malicious
 execution environment. It’s assumed that the application is written by
@@ -1860,8 +1817,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <li><a href="#dom-trustedtypepolicyfactory-ishtml">isHTML(value)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-isscripturl">isScriptURL(value)</a><span>, in §2.3.1</span>
    <li><a href="#dom-trustedtypepolicyfactory-isscript">isScript(value)</a><span>, in §2.3.1</span>
-   <li><a href="#abstract-opdef-issourceexempt">IsSourceExempt</a><span>, in §4.5.6</span>
-   <li><a href="#grammardef-keyword-source">keyword-source</a><span>, in §4.5.5</span>
    <li>
     name
     <ul>
@@ -1910,7 +1865,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><a href="#trustedscript">(interface)</a><span>, in §2.2.2</span>
      <li><a href="#typedef-trustedscript">(type)</a><span>, in §2.2.2</span>
     </ul>
-   <li><a href="#grammardef-trusted-script">'trusted-script'</a><span>, in §4.5.5</span>
    <li>
     TrustedScriptURL
     <ul>
@@ -1939,8 +1893,8 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><a href="#dictdef-trustedtypepolicyoptions">(dictionary)</a><span>, in §2.3.3</span>
      <li><a href="#typedef-trustedtypepolicyoptions">(type)</a><span>, in §2.3.3</span>
     </ul>
-   <li><a href="#extendedattrdef-trustedtypes">TrustedTypes</a><span>, in §2.4.2</span>
    <li><a href="#dom-window-trustedtypes">trustedTypes</a><span>, in §4.1.1</span>
+   <li><a href="#extendedattrdef-trustedtypes">TrustedTypes</a><span>, in §2.4.2</span>
    <li><a href="#trusted-types-directive">trusted-types-directive</a><span>, in §4.5.1</span>
    <li><a href="#tt-expression">tt-expression</a><span>, in §4.5.1</span>
    <li><a href="#tt-policy-name">tt-policy-name</a><span>, in §4.5.1</span>
@@ -1952,13 +1906,13 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-grammardef-report-sample">
    <a href="https://w3c.github.io/webappsec-csp/#grammardef-report-sample">https://w3c.github.io/webappsec-csp/#grammardef-report-sample</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-report-sample">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-grammardef-report-sample">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-grammardef-unsafe-eval">
    <a href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval">https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-grammardef-unsafe-eval">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-grammardef-unsafe-eval">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-policy-directive-set">
@@ -1967,7 +1921,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-policy-directive-set">3.4. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-policy-directive-set①">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-policy-directive-set②">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-policy-directive-set③">4.5.6. IsSourceExempt Algorithm</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-directives">
@@ -1976,7 +1929,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-directives">4.5.1. trusted-types directive</a>
     <li><a href="#ref-for-directives①">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-directives②">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a> <a href="#ref-for-directives③">(2)</a>
-    <li><a href="#ref-for-directives④">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-directives⑤">(2)</a> <a href="#ref-for-directives⑥">(3)</a>
+    <li><a href="#ref-for-directives④">4.5.5. Support for eval(TrustedScript)</a> <a href="#ref-for-directives⑤">(2)</a> <a href="#ref-for-directives⑥">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-policy-disposition">
@@ -1984,7 +1937,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-policy-disposition">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-policy-disposition①">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-policy-disposition②">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-policy-disposition②">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-directive-inline-check">
@@ -1998,7 +1951,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-directive-name">4.5.1. trusted-types directive</a>
     <li><a href="#ref-for-directive-name①">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-directive-name②">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-directive-name③">(2)</a>
+    <li><a href="#ref-for-directive-name②">4.5.5. Support for eval(TrustedScript)</a> <a href="#ref-for-directive-name③">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-violation-policy">
@@ -2019,7 +1972,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-violation-resource">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-resource①">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-resource②">4.5.4. Violation object changes</a>
-    <li><a href="#ref-for-violation-resource③">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-violation-resource③">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-violation-sample">
@@ -2027,7 +1980,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-violation-sample">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-violation-sample①">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-violation-sample②">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-violation-sample②">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-script-src">
@@ -2039,7 +1992,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-source-expression">
    <a href="https://w3c.github.io/webappsec-csp/#source-expression">https://w3c.github.io/webappsec-csp/#source-expression</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-source-expression">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-source-expression①">(2)</a>
+    <li><a href="#ref-for-source-expression">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-directive-value">
@@ -2047,7 +2000,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
    <ul>
     <li><a href="#ref-for-directive-value">4.5.1. trusted-types directive</a> <a href="#ref-for-directive-value①">(2)</a>
     <li><a href="#ref-for-directive-value②">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a> <a href="#ref-for-directive-value③">(2)</a>
-    <li><a href="#ref-for-directive-value④">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-directive-value⑤">(2)</a>
+    <li><a href="#ref-for-directive-value④">4.5.5. Support for eval(TrustedScript)</a> <a href="#ref-for-directive-value⑤">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-violation">
@@ -2210,20 +2163,12 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
     <li><a href="#ref-for-windoworworkerglobalscope">4.1.5. Enforcement in timer functions</a> <a href="#ref-for-windoworworkerglobalscope①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-active-document">
-   <a href="https://html.spec.whatwg.org/multipage/browsers.html#active-document">https://html.spec.whatwg.org/multipage/browsers.html#active-document</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-active-document">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
-   </ul>
-  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-document-csp-list">
    <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-document-csp-list">3.4. Get Trusted Type compliant string</a>
     <li><a href="#ref-for-concept-document-csp-list①">4.5.2. Should sink type mismatch violation be blocked by Content Security Policy?</a>
     <li><a href="#ref-for-concept-document-csp-list②">4.5.3. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-concept-document-csp-list③">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
-    <li><a href="#ref-for-concept-document-csp-list④">4.5.6. IsSourceExempt Algorithm</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-settings-object-global">
@@ -2265,8 +2210,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-ascii-case-insensitive">
    <a href="https://infra.spec.whatwg.org/#ascii-case-insensitive">https://infra.spec.whatwg.org/#ascii-case-insensitive</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-ascii-case-insensitive">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-ascii-case-insensitive①">(2)</a>
-    <li><a href="#ref-for-ascii-case-insensitive②">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
+    <li><a href="#ref-for-ascii-case-insensitive">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-ascii-lowercase">
@@ -2286,14 +2230,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-list-contain">
    <a href="https://infra.spec.whatwg.org/#list-contain">https://infra.spec.whatwg.org/#list-contain</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-list-contain">4.5.5.1. 'trusted-script' support for eval</a>
-    <li><a href="#ref-for-list-contain①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="term-for-iteration-continue">
-   <a href="https://infra.spec.whatwg.org/#iteration-continue">https://infra.spec.whatwg.org/#iteration-continue</a><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-iteration-continue">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-list-contain">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-html-namespace">
@@ -2352,7 +2289,7 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
   <aside class="dfn-panel" data-for="term-for-exceptiondef-evalerror">
    <a href="https://heycam.github.io/webidl/#exceptiondef-evalerror">https://heycam.github.io/webidl/#exceptiondef-evalerror</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-exceptiondef-evalerror">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-exceptiondef-evalerror">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-Exposed">
@@ -2522,7 +2459,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-htmlscriptelement" style="color:initial">HTMLScriptElement</span>
      <li><span class="dfn-paneled" id="term-for-window" style="color:initial">Window</span>
      <li><span class="dfn-paneled" id="term-for-windoworworkerglobalscope" style="color:initial">WindowOrWorkerGlobalScope</span>
-     <li><span class="dfn-paneled" id="term-for-active-document" style="color:initial">active document</span>
      <li><span class="dfn-paneled" id="term-for-concept-document-csp-list" style="color:initial">csp list</span>
      <li><span class="dfn-paneled" id="term-for-concept-settings-object-global" style="color:initial">global object <small>(for environment settings object)</small></span>
      <li><span class="dfn-paneled" id="term-for-dom-innertext" style="color:initial">innerText</span>
@@ -2537,7 +2473,6 @@ to the DOM XSS <a data-link-type="dfn" href="#injection-sink" id="ref-for-inject
      <li><span class="dfn-paneled" id="term-for-ascii-lowercase" style="color:initial">ascii lowercase</span>
      <li><span class="dfn-paneled" id="term-for-string-concatenate" style="color:initial">concatenate</span>
      <li><span class="dfn-paneled" id="term-for-list-contain" style="color:initial">contain</span>
-     <li><span class="dfn-paneled" id="term-for-iteration-continue" style="color:initial">continue</span>
      <li><span class="dfn-paneled" id="term-for-html-namespace" style="color:initial">html namespace</span>
      <li><span class="dfn-paneled" id="term-for-ordered-set" style="color:initial">ordered set</span>
     </ul>
@@ -2813,7 +2748,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-trustedscript①①">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-trustedscript①②">4.2. Integration with SVG</a>
     <li><a href="#ref-for-trustedscript①③">4.5.1.1. trusted-types Pre-Navigation check</a>
-    <li><a href="#ref-for-trustedscript①④">4.5.5.1. 'trusted-script' support for eval</a>
+    <li><a href="#ref-for-trustedscript①④">4.5.5. Support for eval(TrustedScript)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="trustedscripturl">
@@ -2983,7 +2918,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-default-policy">3.2. Get default policy</a>
     <li><a href="#ref-for-default-policy①">4.5.1. trusted-types directive</a>
     <li><a href="#ref-for-default-policy②">4.5.1.1. trusted-types Pre-Navigation check</a>
-    <li><a href="#ref-for-default-policy③">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-default-policy④">(2)</a>
+    <li><a href="#ref-for-default-policy③">4.5.5. Support for eval(TrustedScript)</a> <a href="#ref-for-default-policy④">(2)</a>
     <li><a href="#ref-for-default-policy⑤">6.1. Vendor-specific Extensions and Addons</a>
    </ul>
   </aside>
@@ -3038,8 +2973,7 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string④">4.1.5. Enforcement in timer functions</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑤">4.1.6. Enforcement in event handler content attributes</a>
     <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑥">4.2. Integration with SVG</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">4.5.5.1. 'trusted-script' support for eval</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(2)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑨">(3)</a>
-    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string①⓪">4.5.6. IsSourceExempt Algorithm</a>
+    <li><a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑦">4.5.5. Support for eval(TrustedScript)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑧">(2)</a> <a href="#ref-for-abstract-opdef-get-trusted-type-compliant-string⑨">(3)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="abstract-opdef-process-value-with-a-default-policy">
@@ -3170,20 +3104,6 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <b><a href="#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">#abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-abstract-opdef-should-trusted-type-policy-creation-be-blocked-by-content-security-policy">3.1. Create a Trusted Type Policy</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="grammardef-trusted-script">
-   <b><a href="#grammardef-trusted-script">#grammardef-trusted-script</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-grammardef-trusted-script">4.5.5.1. 'trusted-script' support for eval</a>
-    <li><a href="#ref-for-grammardef-trusted-script①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
-   </ul>
-  </aside>
-  <aside class="dfn-panel" data-for="abstract-opdef-issourceexempt">
-   <b><a href="#abstract-opdef-issourceexempt">#abstract-opdef-issourceexempt</a></b><b>Referenced in:</b>
-   <ul>
-    <li><a href="#ref-for-abstract-opdef-issourceexempt">4.5.5.1. 'trusted-script' support for eval</a>
-    <li><a href="#ref-for-abstract-opdef-issourceexempt①">4.5.5.2. 'trusted-script' support for javascript: URLs</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1333,7 +1333,10 @@ strings (|createdPolicyNames|), this algorithm returns `"Blocked"` if the
 [=violation|Violation=] object [=violation/resource=] also allows `"trusted-types-policy"`
 and `"trusted-types-sink"` as values.
 
-### 'trusted-script' keyword ### {#trusted-script-csp-keyword}
+### Support for eval(TrustedScript) ### {#csp-eval}
+
+This document modifies the [[CSP3#can-compile-strings|EnsureCSPDoesNotBlockStringCompilation]]
+which is reproduced in its entirety below with additions and deletions.
 
 Note: See <a href="https://github.com/tc39/ecma262/issues/938">TC39/ecma262 issue #938</a>
 (adding the value to be compiled to algorithm parameters).
@@ -1355,19 +1358,6 @@ This is subtly different from the CSP directive enforcement portion which reject
 the |calleeRealm| or |callerRealm|'s Content-Security-Policy rejects string compilation.
 </div>
 
-This document modifies the grammar for [[CSP3#keyword-source]]:
-
-<pre dfn-type="grammar" link-type="grammar">
-  <dfn>keyword-source</dfn> = "'self'" / "'unsafe-inline'" / "'unsafe-eval'"
-                       / "'strict-dynamic'" / "'unsafe-hashes'" / "'report-sample'"
-                       / "'unsafe-allow-redirects'" <ins>/ "<dfn>'trusted-script'</dfn>"</ins>
-</pre>
-
-#### 'trusted-script' support for eval #### {#csp-trusted-script-eval}
-
-This document modifies the [[CSP3#can-compile-strings|EnsureCSPDoesNotBlockStringCompilation]]
-which is reproduced in its entirety below with additions and deletions.
-
 Given two [[ECMASCRIPT#realm|realms]] (|callerRealm| and
 |calleeRealm|), and a <del>string</del> <ins>value</ins>
 (|source|), this algorithm returns <del>normally</del>
@@ -1383,13 +1373,10 @@ throws an "`EvalError`" if not:
 
 2.  <ins>If the algorithm throws an error, throw an {{EvalError}}.</ins>
 
-3.  <ins>Let |isExempt| be the result of executing the [$IsSourceExempt$] algorithm with:
-    *   |calleeRealm|’s {{CSP list}} as |cspList|.</ins>
-
-4.  Let |globals| be a list containing |calleeRealm|'s [=Realm/global object=] and |calleeRealm|'s
+3.  Let |globals| be a list containing |calleeRealm|'s [=Realm/global object=] and |calleeRealm|'s
     [=Realm/global object=].
 
-5.  For each |global| in |globals|:
+4.  For each |global| in |globals|:
 
     1.  Let |result| be "`Allowed`".
 
@@ -1403,11 +1390,7 @@ throws an "`EvalError`" if not:
             Otherwise if |policy| contains a [=directive=] whose [=directive/name=] is
             "`default-src`", then set |source-list| to that directive's [=directive/value=].
 
-        3. <ins>If |isExempt| is true and |source-list| contains a
-            [=source expression=] which is an [=ASCII case-insensitive=] match for the
-            string "<a grammar>`'trusted-script'`</a>"), [=continue=].</ins>
-
-        4.  If |source-list| is not `null`, and does not contain a [=source expression=] which is
+        3.  If |source-list| is not `null`, and does not contain a [=source expression=] which is
             an [=ASCII case-insensitive=] match for the string "<a grammar>`'unsafe-eval'`</a>" then:
 
             1.  Let |violation| be the result of executing [[CSP3#create-violation-for-global]] on
@@ -1447,32 +1430,6 @@ Is this a feature or a bug?
 Note: The previous algorithm reports violations via both report-uris where
 callerRealm != calleeRealm.  If [$Get Trusted Type compliant string$] reports an
 error, it only reports it via its |calleeRealm|'s report-uri.
-
-#### 'trusted-script' support for javascript: URLs #### {#csp-trusted-script-javascript-url}
-
-This document modifies the [[CSP3#match-element-to-source-list|Does element match source list for type and source?]]
-algorithm, for it to recognize the 'trusted-script' keyword for `javascript:` navigations.
-
-Add the following step after step 1:
-
-2.  If |type| is `"navigation"`, |list| [=list/contains=] an [=ASCII case-insensitive=]
-    match for the string "<a grammar>`'trusted-script'`</a>" and [$IsSourceExempt$] algorithm executed on [=active document=]'s <a>CSP list</a> returns true,
-    return `"Matches"`.
-
-
-### <dfn abstract-op>IsSourceExempt</dfn> Algorithm ### {#is-source-exempt-algorithm}
-
-The IsSourceExempt algorithm takes a <a>CSP List</a> (|cspList|) and executes
-the following steps:
-
-1.  If |cspList| contains a [[CSP3#content-security-policy-object|policy]] whose
-    <a>directive set</a> contains a [[CSP3#directives|directive]] with a name
-    `"trusted-types"`, return true.
-1.  Return false.
-
-Note: This checks whether Trusted Types enforcement would have rejected the
-input, were it problematic in the callout to [$Get Trusted Type compliant string$].
-
 
 # Security Considerations # {#security-considerations}
 


### PR DESCRIPTION
* eval(TrustedScript) requires `'unsafe-eval'` in `script-src`.
* Navigation to javascript: URLs that were passed to CSP requires `'unsafe-inline'` in `script-src`.