### PR TITLE
Added support for 'trusted-types *' to align better with other CSP directives.

### DIFF
--- a/dist/spec/index.html
+++ b/dist/spec/index.html
@@ -1214,7 +1214,7 @@ Possible extra rowspan handling
 </style>
   <meta content="Bikeshed version 0dd2bba6dfda6c3168490a3a3044dd1d0b1ef8e0" name="generator">
   <link href="https://w3c.github.io/webappsec-trusted-types/dist/spec/" rel="canonical">
-  <meta content="db82179c1fb92cb256cb3bf32886480e4b23cb17" name="document-revision">
+  <meta content="aaf9b745a15eb5952b7fbcada1d917f2788241fb" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1461,7 +1461,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"><a class="logo" href="https://www.w3.org/"> <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72"> </a> </p>
    <h1 class="p-name no-ref" id="title">Trusted Types</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-03-09">9 March 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Editor’s Draft, <time class="dt-updated" datetime="2020-03-11">11 March 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -3101,7 +3101,8 @@ ABNF:</p>
 <pre>directive-name = "trusted-types"
 directive-value = <a data-link-type="dfn" href="#serialized-tt-configuration" id="ref-for-serialized-tt-configuration">serialized-tt-configuration</a>
 <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="serialized-tt-configuration">serialized-tt-configuration</dfn> = ( <a data-link-type="dfn" href="#tt-expression" id="ref-for-tt-expression">tt-expression</a> *( <a href="https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a data-link-type="dfn" href="#tt-expression" id="ref-for-tt-expression①">tt-expression</a> ) )
-<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tt-expression">tt-expression</dfn> = <a data-link-type="dfn" href="#tt-policy-name" id="ref-for-tt-policy-name">tt-policy-name</a>  / <a data-link-type="dfn" href="#tt-keyword" id="ref-for-tt-keyword">tt-keyword</a>
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tt-expression">tt-expression</dfn> = <a data-link-type="dfn" href="#tt-policy-name" id="ref-for-tt-policy-name">tt-policy-name</a>  / <a data-link-type="dfn" href="#tt-keyword" id="ref-for-tt-keyword">tt-keyword</a> / <a data-link-type="dfn" href="#tt-wildcard" id="ref-for-tt-wildcard">tt-wildcard</a>
+<dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tt-wildcard">tt-wildcard</dfn> = "*"
 <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tt-policy-name">tt-policy-name</dfn> = 1*( <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> / "-" / "#" / "=" / "_" / "/" / "@" / "." / "%")
 <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="tt-keyword">tt-keyword</dfn> = "'allow-duplicates'"
 </pre>
@@ -3186,7 +3187,8 @@ for a value <code>'allow-duplicates'</code>, set <var>createViolation</var> to t
 duplicated names.</p>
       <li data-md>
        <p>If <var>directive</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑤">value</a> does not contain a <a data-link-type="dfn" href="#tt-policy-name" id="ref-for-tt-policy-name①">tt-policy-name</a>,
-which value is <var>policyName</var>, set <var>createViolation</var> to true.</p>
+which value is <var>policyName</var>, and <var>directive</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑥">value</a> does not contain a <a data-link-type="dfn" href="#tt-wildcard" id="ref-for-tt-wildcard①">tt-wildcard</a>, set <var>createViolation</var> to true.</p>
+       <p class="note" role="note"><span>Note:</span> <code>trusted-types *</code> allows authors to create policies with any unique names. To allow for multiple policies with the same name, use <code>trusted-types * 'allow-duplicates'</code> or don’t set the <code>trusted-types</code> directive at all.</p>
       <li data-md>
        <p>If <var>createViolation</var> is false, skip to the next <var>policy</var>.</p>
       <li data-md>
@@ -3266,9 +3268,9 @@ throws an "<code>EvalError</code>" if not:
          <p>Let <var>source-list</var> be <code>null</code>.</p>
         <li data-md>
          <p>If <var>policy</var> contains a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives⑧">directive</a> whose <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-name" id="ref-for-directive-name③">name</a> is "<code>script-src</code>", then
-set <var>source-list</var> to that <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑥">value</a>.</p>
+set <var>source-list</var> to that <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives⑨">directive</a>'s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑦">value</a>.</p>
          <p>Otherwise if <var>policy</var> contains a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directives" id="ref-for-directives①⓪">directive</a> whose <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-name" id="ref-for-directive-name④">name</a> is
-"<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑦">value</a>.</p>
+"<code>default-src</code>", then set <var>source-list</var> to that directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-value" id="ref-for-directive-value⑧">value</a>.</p>
         <li data-md>
          <p>If <var>source-list</var> is not <code>null</code>, and does not contain a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#source-expression" id="ref-for-source-expression">source expression</a> which is
 an <a data-link-type="dfn" href="https://infra.spec.whatwg.org/#ascii-case-insensitive" id="ref-for-ascii-case-insensitive">ASCII case-insensitive</a> match for the string "<a data-link-type="grammar" href="https://w3c.github.io/webappsec-csp/#grammardef-unsafe-eval" id="ref-for-grammardef-unsafe-eval"><code>'unsafe-eval'</code></a>" then:</p>
@@ -3539,6 +3541,7 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
    <li><a href="#tt-expression">tt-expression</a><span>, in §4.5.2</span>
    <li><a href="#tt-keyword">tt-keyword</a><span>, in §4.5.2</span>
    <li><a href="#tt-policy-name">tt-policy-name</a><span>, in §4.5.2</span>
+   <li><a href="#tt-wildcard">tt-wildcard</a><span>, in §4.5.2</span>
    <li><a href="#dom-document-write">write()</a><span>, in §4.1.2</span>
    <li><a href="#dom-document-writeln">writeln()</a><span>, in §4.1.2</span>
    <li><a href="#dom-document-writeln">writeln(...text)</a><span>, in §4.1.2</span>
@@ -3657,8 +3660,8 @@ to the <a data-link-type="dfn" href="#injection-sink" id="ref-for-injection-sink
     <li><a href="#ref-for-directive-value">4.5.1. require-trusted-types-for directive</a>
     <li><a href="#ref-for-directive-value①">4.5.2. trusted-types directive</a> <a href="#ref-for-directive-value②">(2)</a>
     <li><a href="#ref-for-directive-value③">4.5.3. Should sink type mismatch violation be blocked by Content Security Policy?</a>
-    <li><a href="#ref-for-directive-value④">4.5.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a> <a href="#ref-for-directive-value⑤">(2)</a>
-    <li><a href="#ref-for-directive-value⑥">4.5.6. Support for eval(TrustedScript)</a> <a href="#ref-for-directive-value⑦">(2)</a>
+    <li><a href="#ref-for-directive-value④">4.5.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a> <a href="#ref-for-directive-value⑤">(2)</a> <a href="#ref-for-directive-value⑥">(3)</a>
+    <li><a href="#ref-for-directive-value⑦">4.5.6. Support for eval(TrustedScript)</a> <a href="#ref-for-directive-value⑧">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-violation">
@@ -4862,6 +4865,13 @@ Is this a feature or a bug?<a href="#issue-649f8da4"> ↵ </a></div>
    <b><a href="#tt-expression">#tt-expression</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-tt-expression">4.5.2. trusted-types directive</a> <a href="#ref-for-tt-expression①">(2)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="tt-wildcard">
+   <b><a href="#tt-wildcard">#tt-wildcard</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-tt-wildcard">4.5.2. trusted-types directive</a>
+    <li><a href="#ref-for-tt-wildcard①">4.5.4. Should Trusted Type policy creation be blocked by Content Security Policy?</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="tt-policy-name">

--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1650,7 +1650,8 @@ ABNF:
 directive-name = "trusted-types"
 directive-value = <a>serialized-tt-configuration</a>
 <dfn>serialized-tt-configuration</dfn> = ( <a>tt-expression</a> *( <a href="https://w3c.github.io/webappsec-csp/#grammardef-required-ascii-whitespace">required-ascii-whitespace</a> <a>tt-expression</a> ) )
-<dfn>tt-expression</dfn> = <a>tt-policy-name</a>  / <a>tt-keyword</a>
+<dfn>tt-expression</dfn> = <a>tt-policy-name</a>  / <a>tt-keyword</a> / <a>tt-wildcard</a>
+<dfn>tt-wildcard</dfn> = "*"
 <dfn>tt-policy-name</dfn> = 1*( <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">ALPHA</a> / <a href="https://tools.ietf.org/html/rfc5234#appendix-B.1">DIGIT</a> / "-" / "#" / "=" / "_" / "/" / "@" / "." / "%")
 <dfn>tt-keyword</dfn> = "'allow-duplicates'"
 </pre>
@@ -1736,7 +1737,10 @@ strings (|createdPolicyNames|), this algorithm returns `"Blocked"` if the
         Note: `trusted-types policyA policyB 'allow-duplicates'` allows authors to create policies with
         duplicated names.
     1.  If |directive|'s [=directive/value=] does not contain a <a>tt-policy-name</a>,
-        which value is |policyName|, set |createViolation| to true.
+        which value is |policyName|, and |directive|'s [=directive/value=] does not contain a <a>tt-wildcard</a>, set |createViolation| to true.
+
+        Note: `trusted-types *` allows authors to create policies with any unique names. To allow for multiple policies with the same name, use
+        `trusted-types * 'allow-duplicates'` or don't set the `trusted-types` directive at all.
     1.  If |createViolation| is false, skip to the next |policy|.
     1.  Let |violation| be the result of executing
         [[CSP#create-violation-for-global|Create a violation object for global, policy, and directive]] on |global|, |policy| and


### PR DESCRIPTION
"trusted-types *" does not imply 'allow-duplicates'.`