### PR TITLE
Fix invalid Web IDL syntax

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1,8 +1,3 @@
-<!--
-Before editing this document, please see
-https://github.com/w3c/webappsec-trusted-types/blob/master/README.md#spec-changes
--->
-
 <pre class='metadata'>
 Title: Trusted Types
 Shortname: trusted-types
@@ -1063,7 +1058,7 @@ Issue: Define for workers.
 This document extends the {{Window}} interface defined by [[HTML5|HTML]]:
 
 <pre class="idl">
-partial interface mixin Window {
+partial interface Window {
   [SecureContext] readonly attribute TrustedTypePolicyFactory trustedTypes;
 };
 </pre>
@@ -1081,7 +1076,7 @@ Issue: Remove the note when the API in Chrome is shipped.
 This document modifies the {{Document}} interface defined by [[HTML5|HTML]]:
 
 <pre class="idl">
-partial interface mixin Document {
+partial interface Document {
   [CEReactions] void write(HTMLString... text);
   [CEReactions] void writeln(HTMLString... text);
 };
@@ -1116,7 +1111,7 @@ Note: Using these IDL attributes is the recommended way of dynamically setting U
 Issue: Figure out what to do with script.setAttribute('src'). See [DOM#789](https://github.com/whatwg/dom/issues/789).
 
 <pre class="idl">
-partial interface mixin HTMLScriptElement : HTMLElement {
+partial interface HTMLScriptElement {
  [CEReactions] attribute [TreatNullAs=EmptyString] ScriptString innerText;
  [CEReactions] attribute ScriptString? textContent;
  [CEReactions] attribute ScriptURLString src;
@@ -1430,15 +1425,15 @@ The [=prepare a script=] algorithm is modified as follows:
 This document modifies following IDL attributes of various DOM elements:
 
 <pre class="idl">
-partial interface mixin HTMLIFrameElement : HTMLElement {
+partial interface HTMLIFrameElement {
   [CEReactions] attribute HTMLString srcdoc;
 };
 
-partial interface HTMLEmbedElement : HTMLElement {
+partial interface HTMLEmbedElement {
   [CEReactions] attribute ScriptURLString src;
 };
 
-partial interface HTMLObjectElement : HTMLElement {
+partial interface HTMLObjectElement {
   [CEReactions] attribute ScriptURLString data;
   [CEReactions] attribute ScriptURLString codeBase; // obsolete
 };
@@ -1550,17 +1545,17 @@ This specification modifies the Worker constuctors and {{importScripts}} functio
 
 <pre class="idl">
 [Exposed=(Window,Worker)]
-partial interface Worker : EventTarget {
+partial interface Worker {
     constructor(ScriptURLString scriptURL, optional WorkerOptions options = {});
 };
 
 [Exposed=(Window,Worker)]
-partial interface SharedWorker : EventTarget {
+partial interface SharedWorker {
   constructor(ScriptURLString scriptURL, optional (DOMString or WorkerOptions) options = {});
 };
 
 [Exposed=Worker]
-partial interface WorkerGlobalScope : EventTarget {
+partial interface WorkerGlobalScope {
   void importScripts(ScriptURLString... urls);
 };
 </pre>
@@ -1571,7 +1566,7 @@ This document modifies the IDL for registering service workers, requiring {{Scri
 
 <pre class="idl">
 [SecureContext, Exposed=(Window,Worker)]
-partial interface ServiceWorkerContainer : EventTarget {
+partial interface ServiceWorkerContainer {
    [NewObject] Promise&lt;ServiceWorkerRegistration> register(ScriptURLString scriptURL, optional RegistrationOptions options = {});
 };
 </pre>
@@ -1582,8 +1577,8 @@ This document modifies the {{SVGAnimatedString}} interface to enforce Trusted Ty
 
 <pre class="idl">
 [Exposed=Window]
-partial interface mixin SVGAnimatedString {
-           attribute (DOMString or TrustedScriptURL) baseVal;
+partial interface SVGAnimatedString {
+  attribute (DOMString or TrustedScriptURL) baseVal;
 };
 </pre>
 


### PR DESCRIPTION
With these changes the Web IDL fragments are possible to parse,
but the use of overloading is still in violation of Web IDL:
https://heycam.github.io/webidl/#idl-overloading