### PR TITLE
Update WebIDL attribute name

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -54,7 +54,7 @@ first step:
     header could be used: This causes the `innerHTML` setter to throw a `TypeError` if a raw string was passed in.
 
     This is possible to polyfill for many setters and
-    methods, apart from the ones that are marked as [`[Unforgeable]`](https://heycam.github.io/webidl/#Unforgeable). 
+    methods, apart from the ones that are marked as [`[LegacyUnforgeable]`](https://heycam.github.io/webidl/#LegacyUnforgeable).
   
     This approach could later be extended to cover other types of risky and easy to misuse APIs (e.g. to cover 
     CSS-based data exfiltration attacks).


### PR DESCRIPTION
`[Unforgeable]` was renamed to `[LegacyUnforgeable]` in April of 2020:

https://github.com/heycam/webidl/pull/870