### PR TITLE
Fix remaining Web IDL issues

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -436,7 +436,7 @@ reference - see [[#extensions-to-the-window-interface]].
 <pre class="idl">
 [Exposed=Window, SecureContext] interface TrustedTypePolicyFactory {
     TrustedTypePolicy createPolicy(
-        DOMString policyName, optional TrustedTypePolicyOptions policyOptions);
+        DOMString policyName, optional TrustedTypePolicyOptions policyOptions = {});
     boolean isHTML(any value);
     boolean isScript(any value);
     boolean isScriptURL(any value);
@@ -1094,7 +1094,7 @@ Issue: Remove the note when the API in Chrome is shipped.
 
 This document modifies the {{Document}} interface defined by [[HTML5|HTML]]:
 
-<pre class="idl">
+<pre class="idl exclude">
 partial interface Document {
   [CEReactions] void write(HTMLString... text);
   [CEReactions] void writeln(HTMLString... text);
@@ -1129,7 +1129,7 @@ Note: Using these IDL attributes is the recommended way of dynamically setting U
 
 Issue: Figure out what to do with script.setAttribute('src'). See [DOM#789](https://github.com/whatwg/dom/issues/789).
 
-<pre class="idl">
+<pre class="idl exclude">
 partial interface HTMLScriptElement {
  [CEReactions] attribute [TreatNullAs=EmptyString] ScriptString innerText;
  [CEReactions] attribute ScriptString? textContent;
@@ -1443,7 +1443,7 @@ The [=prepare a script=] algorithm is modified as follows:
 
 This document modifies following IDL attributes of various DOM elements:
 
-<pre class="idl">
+<pre class="idl exclude">
 partial interface HTMLIFrameElement {
   [CEReactions] attribute HTMLString srcdoc;
 };
@@ -1464,7 +1464,7 @@ Issue: Add base.href enforcement.
 
 This document modifies the {{WindowOrWorkerGlobalScope}} interface mixin:
 
-<pre class="idl">
+<pre class="idl exclude">
 typedef (ScriptString or Function) TrustedTimerHandler;
 
 partial interface mixin WindowOrWorkerGlobalScope {
@@ -1562,7 +1562,7 @@ When <a>validate the string in context</a> is invoked, with |platformObject|, |v
 
 This specification modifies the Worker constuctors and {{importScripts}} function to require {{ScriptURLString}}.
 
-<pre class="idl">
+<pre class="idl exclude">
 [Exposed=(Window,Worker)]
 partial interface Worker : EventTarget {
     constructor(ScriptURLString scriptURL, optional WorkerOptions options = {});
@@ -1583,7 +1583,7 @@ partial interface WorkerGlobalScope : EventTarget {
 
 This document modifies the IDL for registering service workers, requiring {{ScriptURLString}}:
 
-<pre class="idl">
+<pre class="idl exclude">
 [SecureContext, Exposed=(Window,Worker)]
 partial interface ServiceWorkerContainer : EventTarget {
    [NewObject] Promise&lt;ServiceWorkerRegistration> register(ScriptURLString scriptURL, optional RegistrationOptions options = {});
@@ -1594,7 +1594,7 @@ partial interface ServiceWorkerContainer : EventTarget {
 
 This document modifies the {{SVGAnimatedString}} interface to enforce Trusted Types:
 
-<pre class="idl">
+<pre class="idl exclude">
 [Exposed=Window]
 partial interface mixin SVGAnimatedString {
            attribute (DOMString or TrustedScriptURL) baseVal;
@@ -1660,7 +1660,7 @@ Issue: Remove when <a href="https://github.com/whatwg/dom/pull/809">DOM #809</a>
 
 This document modifies the following interfaces defined by [[DOM-Parsing]]:
 
-<pre class="idl">
+<pre class="idl exclude">
 partial interface Element {
   [CEReactions, TreatNullAs=EmptyString] attribute HTMLString outerHTML;
   [CEReactions] void insertAdjacentHTML(DOMString position, HTMLString text);


### PR DESCRIPTION
The default value {} is required by Web IDL.

The exclude attributes will cause the Reffy to not extract the
overloaded IDL into webref. These attributes were previously removed
in https://github.com/w3c/webappsec-trusted-types/pull/297.