### PR TITLE
Fix the type of partial WindowOrWorkerGlobalScope

### DIFF
--- a/spec/index.bs
+++ b/spec/index.bs
@@ -1072,7 +1072,7 @@ which is a {{TrustedTypePolicyFactory}} object.
 This document extends the {{WindowOrWorkerGlobalScope}} interface defined by [[HTML5|HTML]]:
 
 <pre class="idl">
-partial interface WindowOrWorkerGlobalScope {
+partial interface mixin WindowOrWorkerGlobalScope {
   readonly attribute TrustedTypePolicyFactory trustedTypes;
 };
 </pre>


### PR DESCRIPTION
WindowOrWorkerGlobalScope is an interface mixin.

Follow-up to https://github.com/w3c/webappsec-trusted-types/pull/332.